### PR TITLE
Bring back async

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,14 @@
 name: ci
 on:
   pull_request:
+    types: [opened, synchronize]
   push:
     branches:
       - master
       - llvm20
 concurrency:
   # Cancels pending runs when a PR gets updated.
-  group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.actor }}
   cancel-in-progress: true
 permissions:
   # Sets permission policy for `GITHUB_TOKEN`
@@ -15,7 +16,7 @@ permissions:
 jobs:
   x86_64-linux-debug:
     timeout-minutes: 420
-    runs-on: [self-hosted, Linux, x86_64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +24,7 @@ jobs:
         run: sh ci/x86_64-linux-debug.sh
   x86_64-linux-release:
     timeout-minutes: 420
-    runs-on: [self-hosted, Linux, x86_64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,7 +32,7 @@ jobs:
         run: sh ci/x86_64-linux-release.sh
   aarch64-linux-debug:
     timeout-minutes: 480
-    runs-on: [self-hosted, Linux, aarch64]
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +40,7 @@ jobs:
         run: sh ci/aarch64-linux-debug.sh
   aarch64-linux-release:
     timeout-minutes: 480
-    runs-on: [self-hosted, Linux, aarch64]
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +56,7 @@ jobs:
       - name: Build and Test
         run: ci/x86_64-macos-release.sh
   aarch64-macos-debug:
-    runs-on: [self-hosted, macOS, aarch64]
+    runs-on: macos-latest
     env:
       ARCH: "aarch64"
     steps:
@@ -64,7 +65,7 @@ jobs:
       - name: Build and Test
         run: ci/aarch64-macos-debug.sh
   aarch64-macos-release:
-    runs-on: [self-hosted, macOS, aarch64]
+    runs-on: macos-latest
     env:
       ARCH: "aarch64"
     steps:
@@ -73,7 +74,7 @@ jobs:
       - name: Build and Test
         run: ci/aarch64-macos-release.sh
   x86_64-windows-debug:
-    runs-on: [self-hosted, Windows, x86_64]
+    runs-on: windows-latest
     env:
       ARCH: "x86_64"
     steps:
@@ -82,7 +83,7 @@ jobs:
       - name: Build and Test
         run: ci/x86_64-windows-debug.ps1
   x86_64-windows-release:
-    runs-on: [self-hosted, Windows, x86_64]
+    runs-on: windows-latest
     env:
       ARCH: "x86_64"
     steps:

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -1207,6 +1207,10 @@ fn suspendExpr(
     const node_datas = tree.nodes.items(.data);
     const body_node = node_datas[node].lhs;
 
+    const fn_block = astgen.fn_block orelse {
+        return astgen.failNode(node, "cannot suspend outside function scope", .{});
+    };
+
     if (gz.nosuspend_node != 0) {
         return astgen.failNodeNotes(node, "suspend inside nosuspend block", .{}, &[_]u32{
             try astgen.errNoteNode(gz.nosuspend_node, "nosuspend block here", .{}),
@@ -1228,11 +1232,46 @@ fn suspendExpr(
 
     const body_result = try fullBodyExpr(&suspend_scope, &suspend_scope.base, .{ .rl = .none }, body_node, .normal);
     if (!gz.refIsNoReturn(body_result)) {
-        _ = try suspend_scope.addBreak(.break_inline, suspend_inst, .void_value);
+        _ = try suspend_scope.addUnNode(.ret_node, .void_value, node);
     }
-    try suspend_scope.setBlockBody(suspend_inst);
+
+    var cancel_scope = gz.makeSubBlock(scope);
+    defer cancel_scope.unstack();
+
+    try genDefers(&cancel_scope, &fn_block.base, scope, .both_sans_err);
+    _ = try cancel_scope.addUnNode(.ret_node, .void_value, node);
+
+    try setSuspendPayload(suspend_inst, &suspend_scope, &cancel_scope);
 
     return suspend_inst.toRef();
+}
+
+/// Supports `cancel_scope` stacked on `suspend_scope`. Unstacks `cancel_scope` then `suspend_scope`.
+fn setSuspendPayload(
+    suspend_inst: Zir.Inst.Index,
+    suspend_scope: *GenZir,
+    cancel_scope: *GenZir,
+) !void {
+    defer suspend_scope.unstack();
+    defer cancel_scope.unstack();
+    const astgen = suspend_scope.astgen;
+    const suspend_body = suspend_scope.instructionsSliceUpto(cancel_scope);
+    const cancel_body = cancel_scope.instructionsSlice();
+    const suspend_body_len = astgen.countBodyLenAfterFixups(suspend_body);
+    const cancel_body_len = astgen.countBodyLenAfterFixups(cancel_body);
+    try astgen.extra.ensureUnusedCapacity(
+        astgen.gpa,
+        @typeInfo(Zir.Inst.Suspend).@"struct".fields.len + suspend_body_len + cancel_body_len,
+    );
+
+    const zir_datas = astgen.instructions.items(.data);
+    zir_datas[@intFromEnum(suspend_inst)].pl_node.payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.Suspend{
+        .body_len = suspend_body_len,
+        .cancel_body_len = cancel_body_len,
+    });
+
+    astgen.appendBodyWithFixups(suspend_body);
+    astgen.appendBodyWithFixups(cancel_body);
 }
 
 fn awaitExpr(

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -309,7 +309,7 @@ pub const Inst = struct {
         /// Uses the `declaration` union field. Payload is `Declaration`.
         declaration,
         /// Implements `suspend {...}`.
-        /// Uses the `pl_node` union field. Payload is `Block`.
+        /// Uses the `pl_node` union field. Payload is `Suspend`.
         suspend_block,
         /// Boolean NOT. See also `bit_not`.
         /// Uses the `un_node` field.
@@ -2583,6 +2583,14 @@ pub const Inst = struct {
     /// Each operand is an `Index`.
     pub const Block = struct {
         body_len: u32,
+    };
+
+    /// This data is stored inside extra, with two sets of trailing `Ref`:
+    /// * 0. the then body, according to `body_len`.
+    /// * 1. the else body, according to `cancel_body_len`.
+    pub const Suspend = struct {
+        body_len: u32,
+        cancel_body_len: u32,
     };
 
     /// Trailing:

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -872,6 +872,11 @@ pub const Inst = struct {
         /// Operand is unused and set to Ref.none
         work_group_id,
 
+        /// Implements the suspend block.
+        /// Uses the `pl_op` field, payload is `Suspend`.
+        /// Operand is unused and set to Ref.none
+        @"suspend",
+
         pub fn fromCmpOp(op: std.math.CompareOperator, optimized: bool) Tag {
             switch (op) {
                 .lt => return if (optimized) .cmp_lt_optimized else .cmp_lt,
@@ -1166,6 +1171,14 @@ pub const Inst = struct {
 /// Trailing is a list of instruction indexes for every `body_len`.
 pub const Block = struct {
     body_len: u32,
+};
+
+/// This data is stored inside extra, with two sets of trailing `Inst.Ref`:
+/// * 0. the then body, according to `body_len`.
+/// * 1. the cancel body, according to `cancel_body_len`.
+pub const Suspend = struct {
+    body_len: u32,
+    cancel_body_len: u32,
 };
 
 /// Trailing is a list of instruction indexes for every `body_len`.
@@ -1556,6 +1569,7 @@ pub fn typeOfIndex(air: *const Air, inst: Air.Inst.Index, ip: *const InternPool)
         .vector_store_elem,
         .c_va_end,
         .call_async,
+        .@"suspend",
         => return Type.void,
 
         .slice_len,
@@ -1735,6 +1749,7 @@ pub fn mustLower(air: Air, inst: Air.Inst.Index, ip: *const InternPool) bool {
         .sub_safe,
         .mul_safe,
         .intcast_safe,
+        .@"suspend",
         => true,
 
         .add,

--- a/src/Air/types_resolved.zig
+++ b/src/Air/types_resolved.zig
@@ -336,6 +336,20 @@ fn checkBody(air: Air, body: []const Air.Inst.Index, zcu: *Zcu) bool {
                 for (args) |arg| if (!checkRef(arg, zcu)) return false;
             },
 
+            .call_async => {
+                const extra = air.extraData(Air.AsyncCall, data.pl_op.payload);
+                const args: []const Air.Inst.Ref = @ptrCast(air.extra[extra.end..][0..extra.data.args_len]);
+                if (!checkRef(data.pl_op.operand, zcu)) return false;
+                for (args) |arg| if (!checkRef(arg, zcu)) return false;
+            },
+
+            .call_async_alloc => {
+                const extra = air.extraData(Air.AsyncCallAlloc, data.ty_pl.payload);
+                const args: []const Air.Inst.Ref = @ptrCast(air.extra[extra.end..][0..extra.data.args_len]);
+                if (!checkType(data.ty_pl.ty.toType(), zcu)) return false;
+                for (args) |arg| if (!checkRef(arg, zcu)) return false;
+            },
+
             .dbg_var_ptr,
             .dbg_var_val,
             .dbg_arg_inline,
@@ -477,7 +491,7 @@ pub fn checkType(ty: Type, zcu: *Zcu) bool {
 
         .frame,
         .@"anyframe",
-        => @panic("TODO Air.types_resolved.checkType async frames"),
+        => true,
 
         .optional => checkType(ty.childType(zcu), zcu),
         .error_union => checkType(ty.errorUnionPayload(zcu), zcu),

--- a/src/Air/types_resolved.zig
+++ b/src/Air/types_resolved.zig
@@ -393,6 +393,20 @@ fn checkBody(air: Air, body: []const Air.Inst.Index, zcu: *Zcu) bool {
                 )) return false;
             },
 
+            .@"suspend" => {
+                const extra = air.extraData(Air.Suspend, data.pl_op.payload);
+                if (!checkBody(
+                    air,
+                    @ptrCast(air.extra[extra.end..][0..extra.data.body_len]),
+                    zcu,
+                )) return false;
+                if (!checkBody(
+                    air,
+                    @ptrCast(air.extra[extra.end + extra.data.body_len ..][0..extra.data.cancel_body_len]),
+                    zcu,
+                )) return false;
+            },
+
             .switch_br, .loop_switch_br => {
                 const switch_br = air.unwrapSwitch(inst);
                 if (!checkRef(switch_br.operand, zcu)) return false;

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2290,6 +2290,10 @@ pub const Key = union(enum) {
         /// is redundant with `comptime_bits` stored elsewhere.
         comptime_args: Index.Slice,
 
+        /// Index into extra array of the `async_status` corresponding to this function.
+        /// Used for mutating that data.
+        async_status_extra_index: u32,
+
         /// Returns a pointer that becomes invalid after any additions to the `InternPool`.
         fn analysisPtr(func: Func, ip: *const InternPool) *FuncAnalysis {
             const extra = ip.getLocalShared(func.tid).extra.acquire();
@@ -2349,6 +2353,24 @@ pub const Key = union(enum) {
 
             const branch_quota_ptr = func.branchQuotaPtr(ip);
             @atomicStore(u32, branch_quota_ptr, @max(branch_quota_ptr.*, new_branch_quota), .release);
+        }
+
+        /// Returns a pointer that becomes invalid after any additions to the `InternPool`.
+        fn asyncStatusPtr(func: Func, ip: *const InternPool) *AsyncStatus {
+            const extra = ip.getLocalShared(func.tid).extra.acquire();
+            return @ptrCast(&extra.view().items(.@"0")[func.async_status_extra_index]);
+        }
+
+        pub fn asyncStatusUnordered(func: Func, ip: *const InternPool) AsyncStatus {
+            return @atomicLoad(AsyncStatus, func.asyncStatusPtr(ip), .unordered);
+        }
+
+        pub fn setAsyncStatus(func: Func, ip: *InternPool, status: AsyncStatus) void {
+            const extra_mutex = &ip.getLocal(func.tid).mutate.extra.mutex;
+            extra_mutex.lock();
+            defer extra_mutex.unlock();
+
+            @atomicStore(AsyncStatus, func.asyncStatusPtr(ip), status, .release);
         }
 
         /// Returns a pointer that becomes invalid after any additions to the `InternPool`.
@@ -5866,6 +5888,7 @@ pub const Tag = enum(u8) {
         branch_quota: u32,
         /// Points to a `FuncDecl`.
         generic_owner: Index,
+        async_status: AsyncStatus,
     };
 
     pub const FuncCoerced = struct {
@@ -6061,6 +6084,21 @@ pub const FuncAnalysis = packed struct(u32) {
 
     _: u24 = 0,
 };
+
+/// AsyncStatus
+pub const AsyncStatus = enum(u32) {
+    unknown,
+    yes_async,
+    not_async,
+};
+
+fn initAsyncStatus(cc: std.builtin.CallingConvention) AsyncStatus {
+    return switch (cc) {
+        .auto => .unknown,
+        .@"async" => .yes_async,
+        else => .not_async,
+    };
+}
 
 pub const Bytes = struct {
     /// The type of the aggregate
@@ -7364,6 +7402,7 @@ fn extraFuncDecl(tid: Zcu.PerThread.Id, extra: Local.Extra, extra_index: u32) Ke
         .rbrace_column = func_decl.data.rbrace_column,
         .generic_owner = .none,
         .comptime_args = Index.Slice.empty,
+        .async_status_extra_index = 0,
     };
 }
 
@@ -7396,6 +7435,7 @@ fn extraFuncInstance(ip: *const InternPool, tid: Zcu.PerThread.Id, extra: Local.
             .start = end_extra_index + @intFromBool(analysis.inferred_error_set),
             .len = ip.funcTypeParamsLen(func_decl.ty),
         },
+        .async_status_extra_index = extra_index + std.meta.fieldIndex(Tag.FuncInstance, "async_status").?,
     };
 }
 
@@ -9411,6 +9451,7 @@ pub fn getFuncInstance(
         .ty = func_ty,
         .branch_quota = 0,
         .generic_owner = generic_owner,
+        .async_status = initAsyncStatus(generic_owner_ty.cc),
     });
     extra.appendSliceAssumeCapacity(.{@ptrCast(arg.comptime_args)});
 
@@ -9509,6 +9550,7 @@ pub fn getFuncInstanceIes(
         .ty = func_ty,
         .branch_quota = 0,
         .generic_owner = generic_owner,
+        .async_status = initAsyncStatus(generic_owner_ty.cc),
     });
     extra.appendAssumeCapacity(.{@intFromEnum(Index.none)}); // resolved error set
     extra.appendSliceAssumeCapacity(.{@ptrCast(arg.comptime_args)});
@@ -10196,6 +10238,7 @@ fn addExtraAssumeCapacity(extra: Local.Extra.Mutable, item: anytype) u32 {
             TrackedInst.Index,
             TrackedInst.Index.Optional,
             ComptimeAllocIndex,
+            AsyncStatus,
             => @intFromEnum(@field(item, field.name)),
 
             u32,
@@ -10258,6 +10301,7 @@ fn extraDataTrail(extra: Local.Extra, comptime T: type, index: u32) struct { dat
             TrackedInst.Index,
             TrackedInst.Index.Optional,
             ComptimeAllocIndex,
+            AsyncStatus,
             => @enumFromInt(extra_item),
 
             u32,

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -339,6 +339,9 @@ pub fn categorizeOperand(
         .work_group_id,
         => return .none,
 
+        .@"suspend",
+        => return .write,
+
         .not,
         .bitcast,
         .load,
@@ -1001,6 +1004,7 @@ fn analyzeInst(
         .work_item_id,
         .work_group_size,
         .work_group_id,
+        .@"suspend",
         => return analyzeOperands(a, pass, data, inst, .{ .none, .none, .none }),
 
         .inferred_alloc, .inferred_alloc_comptime => unreachable,

--- a/src/Liveness/Verify.zig
+++ b/src/Liveness/Verify.zig
@@ -66,6 +66,7 @@ fn verifyBody(self: *Verify, body: []const Air.Inst.Index) Error!void {
             .work_item_id,
             .work_group_size,
             .work_group_id,
+            .@"suspend",
             => try self.verifyInstOperands(inst, .{ .none, .none, .none }),
 
             .trap, .unreach => {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7969,7 +7969,7 @@ fn analyzeCall(
         const result = switch (call_tag) {
             .call_async_alloc => blk: {
                 try sema.air_extra.ensureUnusedCapacity(gpa, @typeInfo(Air.AsyncCallAlloc).@"struct".fields.len + runtime_args.len);
-                const ptr_frame_ty = try pt.asyncFrameType(callee.toInterned().?);
+                const ptr_frame_ty = try pt.singleMutPtrType(try pt.asyncFrameType(callee.toInterned().?));
                 break :blk try block.addInst(.{
                     .tag = call_tag,
                     .data = .{ .ty_pl = .{

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36921,6 +36921,7 @@ pub fn typeHasOnePossibleValue(sema: *Sema, ty: Type) CompileError!?Value {
             .type_inferred_error_set,
             .type_opaque,
             .type_function,
+            .type_async_frame,
             => null,
 
             .simple_type, // handled above

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -6162,9 +6162,43 @@ fn zirCImport(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileEr
 }
 
 fn zirSuspendBlock(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
-    const src = parent_block.nodeOffset(inst_data.src_node);
-    return sema.failWithUseOfAsync(parent_block, src);
+    const pl_node = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
+    const extra = sema.code.extraData(Zir.Inst.Suspend, pl_node.payload_index);
+
+    const body = sema.code.bodySlice(extra.end, extra.data.body_len);
+    const cancel_body = sema.code.bodySlice(extra.end + body.len, extra.data.cancel_body_len);
+
+    const pt = sema.pt;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    zcu.funcInfo(sema.owner.unwrap().func).setAsyncStatus(ip, .yes_async);
+
+    var body_block = parent_block.makeSubBlock();
+    defer body_block.instructions.deinit(sema.gpa);
+
+    var cancel_body_block = parent_block.makeSubBlock();
+    defer cancel_body_block.instructions.deinit(sema.gpa);
+
+    _ = try sema.resolveInlineBody(&body_block, body, inst);
+    _ = try sema.resolveInlineBody(&cancel_body_block, cancel_body, inst);
+
+    try sema.air_extra.ensureUnusedCapacity(sema.gpa, @typeInfo(Air.Suspend).@"struct".fields.len +
+        body_block.instructions.items.len + cancel_body_block.instructions.items.len);
+    const suspend_inst = try parent_block.addInst(.{
+        .tag = .@"suspend",
+        .data = .{ .pl_op = .{
+            .operand = .none,
+            .payload = sema.addExtraAssumeCapacity(Air.Suspend{
+                .body_len = @intCast(body_block.instructions.items.len),
+                .cancel_body_len = @intCast(body_block.instructions.items.len),
+            }),
+        } },
+    });
+
+    sema.air_extra.appendSliceAssumeCapacity(@ptrCast(body_block.instructions.items));
+    sema.air_extra.appendSliceAssumeCapacity(@ptrCast(cancel_body_block.instructions.items));
+
+    return suspend_inst;
 }
 
 fn zirBlock(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {

--- a/src/Sema/bitcast.zig
+++ b/src/Sema/bitcast.zig
@@ -253,6 +253,7 @@ const UnpackValueBits = struct {
             .func_type,
             .error_set_type,
             .inferred_error_set_type,
+            .async_frame_type,
             .variable,
             .@"extern",
             .func,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -397,9 +397,10 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
             return print(Type.fromInterned(child), writer, pt);
         },
         .async_frame_type => |fn_index| {
-            _ = fn_index;
-            // TODO
-            try writer.writeAll("@Frame()");
+            const func_nav = ip.getNav(zcu.funcInfo(fn_index).owner_nav);
+            try writer.print("@Frame({})", .{
+                func_nav.fqn.fmt(ip),
+            });
         },
 
         // values, not types

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1545,8 +1545,18 @@ pub fn abiSizeInner(
             .enum_type => return .{ .scalar = Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).abiSize(zcu) },
 
             .async_frame_type => {
-                // TODO
-                @panic("they asked for the size of an async frame");
+                switch (strat) {
+                    .sema, .eager => unreachable,
+                    .lazy => {
+                        const pt = strat.pt(zcu, tid);
+                        return .{
+                            .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                                .ty = .comptime_int_type,
+                                .storage = .{ .lazy_size = ty.toIntern() },
+                            } })),
+                        };
+                    },
+                }
             },
 
             // values, not types

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -3417,6 +3417,10 @@ pub fn singleErrorSetType(pt: Zcu.PerThread, name: InternPool.NullTerminatedStri
     return Type.fromInterned(try pt.zcu.intern_pool.getErrorSetType(pt.zcu.gpa, pt.tid, names));
 }
 
+pub fn asyncFrameType(pt: Zcu.PerThread, func_index: InternPool.Index) Allocator.Error!Type {
+    return Type.fromInterned(try pt.intern(.{ .async_frame_type = func_index }));
+}
+
 /// Sorts `names` in place.
 pub fn errorSetFromUnsortedNames(
     pt: Zcu.PerThread,

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -799,6 +799,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .call_always_tail  => try self.airCall(inst, .always_tail),
             .call_never_tail   => try self.airCall(inst, .never_tail),
             .call_never_inline => try self.airCall(inst, .never_inline),
+            .call_async        => try self.airCall(inst, .async_kw),
+            .call_async_alloc  => try self.airCall(inst, .async_kw),
 
             .atomic_store_unordered => try self.airAtomicStore(inst, .unordered),
             .atomic_store_monotonic => try self.airAtomicStore(inst, .monotonic),
@@ -4245,6 +4247,7 @@ fn airFrameAddress(self: *Self, inst: Air.Inst.Index) InnerError!void {
 
 fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier) InnerError!void {
     if (modifier == .always_tail) return self.fail("TODO implement tail calls for aarch64", .{});
+    if (modifier == .async_kw) return self.fail("TODO implement async calls for aarch64", .{});
     const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const callee = pl_op.operand;
     const extra = self.air.extraData(Air.Call, pl_op.payload);

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -889,6 +889,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .work_item_id => unreachable,
             .work_group_size => unreachable,
             .work_group_id => unreachable,
+
+            .@"suspend" => return self.fail("TODO implement suspend", .{}),
             // zig fmt: on
         }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -878,6 +878,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .work_item_id => unreachable,
             .work_group_size => unreachable,
             .work_group_id => unreachable,
+
+            .@"suspend" => return self.fail("TODO implement suspend", .{}),
             // zig fmt: on
         }
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -788,6 +788,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .call_always_tail  => try self.airCall(inst, .always_tail),
             .call_never_tail   => try self.airCall(inst, .never_tail),
             .call_never_inline => try self.airCall(inst, .never_inline),
+            .call_async        => try self.airCall(inst, .async_kw),
+            .call_async_alloc  => try self.airCall(inst, .async_kw),
 
             .atomic_store_unordered => try self.airAtomicStore(inst, .unordered),
             .atomic_store_monotonic => try self.airAtomicStore(inst, .monotonic),
@@ -4227,6 +4229,7 @@ fn airFrameAddress(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier) !void {
     if (modifier == .always_tail) return self.fail("TODO implement tail calls for arm", .{});
+    if (modifier == .async_kw) return self.fail("TODO implement async calls for arm", .{});
     const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const callee = pl_op.operand;
     const extra = self.air.extraData(Air.Call, pl_op.payload);

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1620,6 +1620,8 @@ fn genBody(func: *Func, body: []const Air.Inst.Index) InnerError!void {
             .call_always_tail  => try func.airCall(inst, .always_tail),
             .call_never_tail   => try func.airCall(inst, .never_tail),
             .call_never_inline => try func.airCall(inst, .never_inline),
+            .call_async        => try func.airCall(inst, .async_kw),
+            .call_async_alloc  => try func.airCall(inst, .async_kw),
 
             .atomic_store_unordered => try func.airAtomicStore(inst, .unordered),
             .atomic_store_monotonic => try func.airAtomicStore(inst, .monotonic),
@@ -4782,6 +4784,7 @@ fn airFrameAddress(func: *Func, inst: Air.Inst.Index) !void {
 
 fn airCall(func: *Func, inst: Air.Inst.Index, modifier: std.builtin.CallModifier) !void {
     if (modifier == .always_tail) return func.fail("TODO implement tail calls for riscv64", .{});
+    if (modifier == .async_kw) return func.fail("TODO implement async calls for riscv64", .{});
     const pl_op = func.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const callee = pl_op.operand;
     const extra = func.air.extraData(Air.Call, pl_op.payload);

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -1703,6 +1703,8 @@ fn genBody(func: *Func, body: []const Air.Inst.Index) InnerError!void {
             .work_item_id => unreachable,
             .work_group_size => unreachable,
             .work_group_id => unreachable,
+
+            .@"suspend" => return func.fail("TODO implement suspend", .{}),
             // zig fmt: on
         }
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -642,6 +642,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .call_always_tail  => try self.airCall(inst, .always_tail),
             .call_never_tail   => try self.airCall(inst, .never_tail),
             .call_never_inline => try self.airCall(inst, .never_inline),
+            .call_async        => try self.airCall(inst, .async_kw),
+            .call_async_alloc  => try self.airCall(inst, .async_kw),
 
             .atomic_store_unordered => @panic("TODO try self.airAtomicStore(inst, .unordered)"),
             .atomic_store_monotonic => @panic("TODO try self.airAtomicStore(inst, .monotonic)"),
@@ -1286,6 +1288,7 @@ fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier) !void {
     if (modifier == .always_tail) return self.fail("TODO implement tail calls for {}", .{self.target.cpu.arch});
+    if (modifier == .async_kw) return self.fail("TODO implement async calls for {}", .{self.target.cpu.arch});
 
     const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const callee = pl_op.operand;

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -732,6 +732,8 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
             .work_item_id => unreachable,
             .work_group_size => unreachable,
             .work_group_id => unreachable,
+
+            .@"suspend" => return self.fail("TODO implement suspend", .{}),
             // zig fmt: on
         }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -2091,6 +2091,8 @@ fn genInst(cg: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .work_group_size,
         .work_group_id,
         => unreachable,
+
+        .@"suspend" => return cg.fail("TODO implement suspend", .{}),
     };
 }
 

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -1950,6 +1950,8 @@ fn genInst(cg: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         .call_always_tail => cg.airCall(inst, .always_tail),
         .call_never_tail => cg.airCall(inst, .never_tail),
         .call_never_inline => cg.airCall(inst, .never_inline),
+        .call_async => cg.airCall(inst, .async_kw),
+        .call_async_alloc => cg.airCall(inst, .async_kw),
 
         .is_err => cg.airIsErr(inst, .i32_ne),
         .is_non_err => cg.airIsErr(inst, .i32_eq),
@@ -2200,6 +2202,7 @@ fn airRetLoad(cg: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 fn airCall(cg: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModifier) InnerError!void {
     const wasm = cg.wasm;
     if (modifier == .always_tail) return cg.fail("TODO implement tail calls for wasm", .{});
+    if (modifier == .async_kw) return cg.fail("TODO implement async calls for wasm", .{});
     const pl_op = cg.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const extra = cg.air.extraData(Air.Call, pl_op.payload);
     const args: []const Air.Inst.Ref = @ptrCast(cg.air.extra[extra.end..][0..extra.data.args_len]);
@@ -3185,6 +3188,7 @@ fn lowerConstant(cg: *CodeGen, val: Value, ty: Type) InnerError!WValue {
         .func_type,
         .error_set_type,
         .inferred_error_set_type,
+        .async_frame_type,
         => unreachable, // types, not values
 
         .undef => unreachable, // handled above

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -53791,6 +53791,8 @@ fn genBody(cg: *CodeGen, body: []const Air.Inst.Index) InnerError!void {
             .work_item_id => unreachable,
             .work_group_size => unreachable,
             .work_group_id => unreachable,
+
+            .@"suspend" => return cg.fail("TODO implement suspend", .{}),
         }
         try cg.resetTemps();
         cg.checkInvariantsAfterAirInst();

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -20803,6 +20803,8 @@ fn genBody(cg: *CodeGen, body: []const Air.Inst.Index) InnerError!void {
             .call_always_tail => try cg.airCall(inst, .always_tail, .{ .safety = true }),
             .call_never_tail => try cg.airCall(inst, .never_tail, .{ .safety = true }),
             .call_never_inline => try cg.airCall(inst, .never_inline, .{ .safety = true }),
+            .call_async => try cg.airCall(inst, .async_kw, .{ .safety = true }),
+            .call_async_alloc => try cg.airCall(inst, .async_kw, .{ .safety = true }),
 
             .clz => |air_tag| if (use_old) try cg.airClz(inst) else {
                 const ty_op = air_datas[@intFromEnum(inst)].ty_op;
@@ -63586,6 +63588,7 @@ fn airFrameAddress(self: *CodeGen, inst: Air.Inst.Index) !void {
 
 fn airCall(self: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModifier, opts: CopyOptions) !void {
     if (modifier == .always_tail) return self.fail("TODO implement tail calls for x86_64", .{});
+    if (modifier == .async_kw) return self.fail("TODO implement async calls for x86_64", .{});
 
     const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const extra = self.air.extraData(Air.Call, pl_op.payload);

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -221,6 +221,7 @@ pub fn generateSymbol(
         .func_type,
         .error_set_type,
         .inferred_error_set_type,
+        .async_frame_type,
         => unreachable, // types, not values
 
         .undef => unreachable, // handled above

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3452,6 +3452,8 @@ fn genBodyInner(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail,
             .work_group_id,
             => unreachable,
 
+            .@"suspend" => return f.fail("TODO implement suspend", .{}),
+
             // Instructions that are known to always be `noreturn` based on their tag.
             .br              => return airBr(f, inst),
             .repeat          => return airRepeat(f, inst),

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -956,6 +956,7 @@ pub const DeclGen = struct {
             .func_type,
             .error_set_type,
             .inferred_error_set_type,
+            .async_frame_type,
             // memoization, not values
             .memoized_call,
             => unreachable,
@@ -1805,6 +1806,7 @@ pub const DeclGen = struct {
                 .anyframe_type,
                 .opaque_type,
                 .func_type,
+                .async_frame_type,
                 => unreachable,
 
                 .undef,

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -3485,6 +3485,8 @@ fn genBodyInner(f: *Function, body: []const Air.Inst.Index) error{ AnalysisFail,
             .call_always_tail  => .none,
             .call_never_tail   => try airCall(f, inst, .never_tail),
             .call_never_inline => try airCall(f, inst, .never_inline),
+            .call_async        => try airCall(f, inst, .async_kw),
+            .call_async_alloc  => try airCall(f, inst, .async_kw),
 
             // zig fmt: on
         };
@@ -4516,6 +4518,8 @@ fn airCall(
     inst: Air.Inst.Index,
     modifier: std.builtin.CallModifier,
 ) !CValue {
+    if (modifier == .async_kw) return f.fail("TODO: C backend: implement async calls", .{});
+
     const pt = f.object.dg.pt;
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;

--- a/src/codegen/c/Type.zig
+++ b/src/codegen/c/Type.zig
@@ -1967,6 +1967,7 @@ pub const Pool = struct {
                     return pool.fromFields(allocator, .@"struct", &fields, kind);
                 },
                 .anyframe_type => unreachable,
+                .async_frame_type => unreachable,
                 .error_union_type => |error_union_info| {
                     const error_set_bits = pt.zcu.errorSetBits();
                     const error_set_ctype = try pool.fromIntInfo(allocator, .{

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3418,6 +3418,7 @@ pub const Object = struct {
                     return o.builder.structType(.normal, fields[0..fields_len]);
                 },
                 .anyframe_type => @panic("TODO implement lowerType for AnyFrame types"),
+                .async_frame_type => @panic("TODO implement lowerType for AnyFrame types"),
                 .error_union_type => |error_union_type| {
                     // Must stay in sync with `codegen.errUnionPayloadOffset`.
                     // See logic in `lowerPtr`.
@@ -3912,6 +3913,7 @@ pub const Object = struct {
             .func_type,
             .error_set_type,
             .inferred_error_set_type,
+            .async_frame_type,
             => unreachable, // types, not values
 
             .undef => unreachable, // handled above

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1517,6 +1517,8 @@ pub const Object = struct {
         var args: std.ArrayListUnmanaged(Builder.Value) = .empty;
         defer args.deinit(gpa);
 
+        try attributes.addFnAttr(.presplitcoroutine, &o.builder);
+
         {
             var it = iterateParamTypes(o, fn_info);
             while (try it.next()) |lowering| {
@@ -1533,7 +1535,7 @@ pub const Object = struct {
                         if (isByRef(param_ty, zcu)) {
                             const alignment = param_ty.abiAlignment(zcu).toLlvm();
                             const param_llvm_ty = param.typeOfWip(&wip);
-                            const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, alignment, target);
+                            const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, .none, alignment, target);
                             _ = try wip.store(.normal, param, arg_ptr, alignment);
                             args.appendAssumeCapacity(arg_ptr);
                         } else {
@@ -1581,7 +1583,7 @@ pub const Object = struct {
 
                         const param_llvm_ty = try o.lowerType(param_ty);
                         const alignment = param_ty.abiAlignment(zcu).toLlvm();
-                        const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, alignment, target);
+                        const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, .none, alignment, target);
                         _ = try wip.store(.normal, param, arg_ptr, alignment);
 
                         args.appendAssumeCapacity(if (isByRef(param_ty, zcu))
@@ -1626,7 +1628,7 @@ pub const Object = struct {
                         const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                         const param_llvm_ty = try o.lowerType(param_ty);
                         const param_alignment = param_ty.abiAlignment(zcu).toLlvm();
-                        const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, param_alignment, target);
+                        const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, .none, param_alignment, target);
                         const llvm_ty = try o.builder.structType(.normal, field_types);
                         for (0..field_types.len) |field_i| {
                             const param = wip.arg(llvm_arg_i);
@@ -1650,7 +1652,7 @@ pub const Object = struct {
                         llvm_arg_i += 1;
 
                         const alignment = param_ty.abiAlignment(zcu).toLlvm();
-                        const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, alignment, target);
+                        const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, .none, alignment, target);
                         _ = try wip.store(.normal, param, arg_ptr, alignment);
 
                         args.appendAssumeCapacity(if (isByRef(param_ty, zcu))
@@ -1665,7 +1667,7 @@ pub const Object = struct {
                         llvm_arg_i += 1;
 
                         const alignment = param_ty.abiAlignment(zcu).toLlvm();
-                        const arg_ptr = try buildAllocaInner(&wip, param.typeOfWip(&wip), alignment, target);
+                        const arg_ptr = try buildAllocaInner(&wip, param.typeOfWip(&wip), .none, alignment, target);
                         _ = try wip.store(.normal, param, arg_ptr, alignment);
 
                         args.appendAssumeCapacity(if (isByRef(param_ty, zcu))
@@ -1759,6 +1761,32 @@ pub const Object = struct {
         };
         defer fg.deinit();
         deinit_wip = false;
+
+        if (true) {
+            // const fl = try fg.lowerAsyncFrame();
+            // fl.ty.
+
+            const afp = try fg.lowerAsyncFuncPtr();
+            const afp_val = try o.builder.structConst(afp.ty, &.{
+                function_index.toConst(&o.builder),
+                try o.builder.intConst(.i32, 0),
+            });
+            const afp_variable = try o.builder.addVariable(
+                try o.builder.strtabString("__afp"),
+                afp.ty,
+                .default,
+            );
+            try afp_variable.setInitializer(afp_val, &o.builder);
+            function_index.setPrefix(afp_variable.toConst(&o.builder), &o.builder);
+
+            const byte_size = @divExact(target.ptrBitWidth(), 8);
+            const context_size = try o.builder.intValue(.i32, byte_size);
+            const context_align = try o.builder.intValue(.i32, 0);
+            const context_arg = try o.builder.intValue(.i32, 0);
+            const token = try fg.wip.callIntrinsic(.normal, .none, .@"coro.id.async", &.{}, &.{ context_size, context_align, context_arg, afp_variable.toValue(&o.builder) }, "");
+            // _ = token;
+            _ = try fg.wip.callIntrinsic(.normal, .none, .@"coro.begin", &.{}, &.{ token, try o.builder.nullValue(.ptr) }, "");
+        }
 
         fg.genBody(air.getMainBody(), .poi) catch |err| switch (err) {
             error.CodegenFail => {
@@ -2840,7 +2868,27 @@ pub const Object = struct {
             .null => unreachable,
             .enum_literal => unreachable,
 
-            .frame => @panic("TODO implement lowerDebugType for Frame types"),
+            .frame => {
+                const func_index = ip.indexToKey(ty.toIntern()).async_frame_type;
+                const func = zcu.funcInfo(func_index);
+                _ = func;
+
+                const elem_di_ty = try o.lowerDebugType(Type.u8);
+                const name = try o.allocTypeName(ty);
+                defer gpa.free(name);
+                const ptr_di_ty = try o.builder.debugPointerType(
+                    try o.builder.metadataString(name),
+                    .none,
+                    .none,
+                    0,
+                    elem_di_ty,
+                    target.ptrBitWidth(),
+                    target.ptrBitWidth() * 2, // alignment
+                    0,
+                );
+                try o.debug_type_map.put(gpa, ty, ptr_di_ty);
+                return ptr_di_ty;
+            },
             .@"anyframe" => @panic("TODO implement lowerDebugType for AnyFrame types"),
         }
     }
@@ -3723,6 +3771,16 @@ pub const Object = struct {
         };
         return if (lower_elem_ty) try o.lowerType(elem_ty) else .i8;
     }
+
+    // fn lowerAsyncFrameHeader(o: *Object, ret_ty: Type) Allocator.Error!Builder.Type {
+    //     const l = asyncFrameLayout();
+    //     var fields: [4]Builder.Type = undefined;
+    //     fields[l.fn_ptr] = .ptr;
+    //     fields[l.resume_index] = try o.lowerType(Type.usize);
+    //     fields[l.awaiter] = .ptr;
+    //     fields[l.ret_val] = try o.lowerType(ret_ty);
+    //     return o.builder.structType(.normal, &fields);
+    // }
 
     fn lowerTypeFn(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Builder.Type {
         const pt = o.pt;
@@ -5304,14 +5362,13 @@ pub const FuncGen = struct {
                     if (self.typeOfIndex(inst).isNoReturn(zcu)) return;
                     break :res res;
                 },
-                .call, .call_always_tail, .call_never_tail, .call_never_inline, .call_async, .call_async_alloc => |tag| res: {
+                .call, .call_always_tail, .call_never_tail, .call_never_inline, .call_async => |tag| res: {
                     const res = try self.airCall(inst, switch (tag) {
                         .call              => .auto,
                         .call_always_tail  => .always_tail,
                         .call_never_tail   => .never_tail,
                         .call_never_inline => .never_inline,
                         .call_async        => .async_kw,
-                        .call_async_alloc  => .async_kw,
                         else               => unreachable,
                     });
                     // TODO: the AIR we emit for calls is a bit weird - the instruction has
@@ -5320,6 +5377,7 @@ pub const FuncGen = struct {
                     //if (self.typeOfIndex(inst).isNoReturn(mod)) return;
                     break :res res;
                 },
+                .call_async_alloc => try self.airCallAsyncAlloc(inst),
 
                 // zig fmt: on
             };
@@ -5427,6 +5485,52 @@ pub const FuncGen = struct {
         AlwaysInline,
     };
 
+    fn airCallAsyncAlloc(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
+        // _ = self;
+        // _ = inst;
+
+        const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
+        const extra = self.air.extraData(Air.AsyncCallAlloc, ty_pl.payload);
+        // const args: []const Air.Inst.Ref = @ptrCast(self.air.extra[extra.end..][0..extra.data.args_len]);
+        const o = self.ng.object;
+        const pt = o.pt;
+        const zcu = pt.zcu;
+        const callee = try self.resolveInst(extra.data.callee);
+        // const callee_ty = self.typeOf(extra.data.callee);
+        // const zig_fn_ty = switch (callee_ty.zigTypeTag(zcu)) {
+        //     .@"fn" => callee_ty,
+        //     .pointer => callee_ty.childType(zcu),
+        //     else => unreachable,
+        // };
+        // const fn_info = zcu.typeToFunc(zig_fn_ty).?;
+        const target = zcu.getTarget();
+
+        var llvm_args = std.ArrayList(Builder.Value).init(self.gpa);
+        defer llvm_args.deinit();
+
+        var attributes: Builder.FunctionAttributes.Wip = .{};
+        defer attributes.deinit(&o.builder);
+
+        const l = AsyncFuncPtrLayout.create();
+        const afp = try self.lowerAsyncFuncPtr();
+        const afp_ptr_ptr = try self.wip.gep(.inbounds, .ptr, callee, &.{
+            try o.builder.intValue(.i32, -1),
+        }, "");
+        const afp_ptr = try self.wip.load(.normal, .ptr, afp_ptr_ptr, .default, "");
+        const afp_size_ptr = try self.wip.gepStruct(afp.ty, afp_ptr, l.context_size, "");
+
+        // const afp_ptr = try self.wip.cast(.bitcast, callee, .ptr, "");
+        // const afp_size_ptr = try self.wip.gepStruct(afp.ty, afp_ptr, l.context_size, "");
+        const address_space = llvmAllocaAddressSpace(target);
+        const afp_size = try self.wip.load(.normal, afp.fields[l.context_size], afp_size_ptr, .default, "");
+        const frame_alloca = try self.wip.alloca(.normal, .i8, afp_size, .default, address_space, "");
+        const frame_ptr = try self.wip.cast(.bitcast, frame_alloca, .ptr, "");
+
+        // try self.addCallArgs(args, &llvm_args, fn_info, &attributes, sret, err_return_tracing);
+
+        return frame_ptr;
+    }
+
     fn airCall(self: *FuncGen, inst: Air.Inst.Index, modifier: std.builtin.CallModifier) !Builder.Value {
         if (modifier == .async_kw) return self.todo("implement async calls for llvm", .{});
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
@@ -5435,7 +5539,6 @@ pub const FuncGen = struct {
         const o = self.ng.object;
         const pt = o.pt;
         const zcu = pt.zcu;
-        const ip = &zcu.intern_pool;
         const callee_ty = self.typeOf(pl_op.operand);
         const zig_fn_ty = switch (callee_ty.zigTypeTag(zcu)) {
             .@"fn" => callee_ty,
@@ -5479,6 +5582,84 @@ pub const FuncGen = struct {
             assert(self.err_ret_trace != .none);
             try llvm_args.append(self.err_ret_trace);
         }
+
+        try self.addCallArgs(args, &llvm_args, fn_info, &attributes, sret, err_return_tracing);
+
+        const call = try self.wip.call(
+            switch (modifier) {
+                .auto, .never_inline => .normal,
+                .never_tail => .notail,
+                .always_tail => .musttail,
+                .async_kw, .no_async, .always_inline, .compile_time => unreachable,
+            },
+            toLlvmCallConvTag(fn_info.cc, target).?,
+            try attributes.finish(&o.builder),
+            try o.lowerType(zig_fn_ty),
+            llvm_fn,
+            llvm_args.items,
+            "",
+        );
+
+        if (fn_info.return_type == .noreturn_type and modifier != .always_tail) {
+            return .none;
+        }
+
+        if (self.liveness.isUnused(inst) or !return_type.hasRuntimeBitsIgnoreComptime(zcu)) {
+            return .none;
+        }
+
+        const llvm_ret_ty = try o.lowerType(return_type);
+        if (ret_ptr) |rp| {
+            if (isByRef(return_type, zcu)) {
+                return rp;
+            } else {
+                // our by-ref status disagrees with sret so we must load.
+                const return_alignment = return_type.abiAlignment(zcu).toLlvm();
+                return self.wip.load(.normal, llvm_ret_ty, rp, return_alignment, "");
+            }
+        }
+
+        const abi_ret_ty = try lowerFnRetTy(o, fn_info);
+
+        if (abi_ret_ty != llvm_ret_ty) {
+            // In this case the function return type is honoring the calling convention by having
+            // a different LLVM type than the usual one. We solve this here at the callsite
+            // by using our canonical type, then loading it if necessary.
+            const alignment = return_type.abiAlignment(zcu).toLlvm();
+            const rp = try self.buildAlloca(abi_ret_ty, alignment);
+            _ = try self.wip.store(.normal, call, rp, alignment);
+            return if (isByRef(return_type, zcu))
+                rp
+            else
+                try self.wip.load(.normal, llvm_ret_ty, rp, alignment, "");
+        }
+
+        if (isByRef(return_type, zcu)) {
+            // our by-ref status disagrees with sret so we must allocate, store,
+            // and return the allocation pointer.
+            const alignment = return_type.abiAlignment(zcu).toLlvm();
+            const rp = try self.buildAlloca(llvm_ret_ty, alignment);
+            _ = try self.wip.store(.normal, call, rp, alignment);
+            return rp;
+        } else {
+            return call;
+        }
+    }
+
+    fn addCallArgs(
+        self: *FuncGen,
+        args: []const Air.Inst.Ref,
+        llvm_args: *std.ArrayList(Builder.Value),
+        fn_info: InternPool.Key.FuncType,
+        attributes: *Builder.FunctionAttributes.Wip,
+        sret: bool,
+        err_return_tracing: bool,
+    ) !void {
+        const o = self.ng.object;
+        const pt = o.pt;
+        const zcu = pt.zcu;
+        const target = zcu.getTarget();
+        const ip = &zcu.intern_pool;
 
         var it = iterateParamTypes(o, fn_info);
         while (try it.nextCall(self, args)) |lowering| switch (lowering) {
@@ -5622,7 +5803,7 @@ pub const FuncGen = struct {
                     const param_index = it.zig_index - 1;
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[param_index]);
                     if (!isByRef(param_ty, zcu)) {
-                        try o.addByValParamAttrs(&attributes, param_ty, param_index, fn_info, it.llvm_index - 1);
+                        try o.addByValParamAttrs(attributes, param_ty, param_index, fn_info, it.llvm_index - 1);
                     }
                 },
                 .byref => {
@@ -5630,7 +5811,7 @@ pub const FuncGen = struct {
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[param_index]);
                     const param_llvm_ty = try o.lowerType(param_ty);
                     const alignment = param_ty.abiAlignment(zcu).toLlvm();
-                    try o.addByRefParamAttrs(&attributes, it.llvm_index - 1, alignment, it.byval_attr, param_llvm_ty);
+                    try o.addByRefParamAttrs(attributes, it.llvm_index - 1, alignment, it.byval_attr, param_llvm_ty);
                 },
                 .byref_mut => try attributes.addParamAttr(it.llvm_index - 1, .noundef, &o.builder),
                 // No attributes needed for these.
@@ -5667,66 +5848,6 @@ pub const FuncGen = struct {
                 },
             };
         }
-
-        const call = try self.wip.call(
-            switch (modifier) {
-                .auto, .never_inline => .normal,
-                .never_tail => .notail,
-                .always_tail => .musttail,
-                .async_kw, .no_async, .always_inline, .compile_time => unreachable,
-            },
-            toLlvmCallConvTag(fn_info.cc, target).?,
-            try attributes.finish(&o.builder),
-            try o.lowerType(zig_fn_ty),
-            llvm_fn,
-            llvm_args.items,
-            "",
-        );
-
-        if (fn_info.return_type == .noreturn_type and modifier != .always_tail) {
-            return .none;
-        }
-
-        if (self.liveness.isUnused(inst) or !return_type.hasRuntimeBitsIgnoreComptime(zcu)) {
-            return .none;
-        }
-
-        const llvm_ret_ty = try o.lowerType(return_type);
-        if (ret_ptr) |rp| {
-            if (isByRef(return_type, zcu)) {
-                return rp;
-            } else {
-                // our by-ref status disagrees with sret so we must load.
-                const return_alignment = return_type.abiAlignment(zcu).toLlvm();
-                return self.wip.load(.normal, llvm_ret_ty, rp, return_alignment, "");
-            }
-        }
-
-        const abi_ret_ty = try lowerFnRetTy(o, fn_info);
-
-        if (abi_ret_ty != llvm_ret_ty) {
-            // In this case the function return type is honoring the calling convention by having
-            // a different LLVM type than the usual one. We solve this here at the callsite
-            // by using our canonical type, then loading it if necessary.
-            const alignment = return_type.abiAlignment(zcu).toLlvm();
-            const rp = try self.buildAlloca(abi_ret_ty, alignment);
-            _ = try self.wip.store(.normal, call, rp, alignment);
-            return if (isByRef(return_type, zcu))
-                rp
-            else
-                try self.wip.load(.normal, llvm_ret_ty, rp, alignment, "");
-        }
-
-        if (isByRef(return_type, zcu)) {
-            // our by-ref status disagrees with sret so we must allocate, store,
-            // and return the allocation pointer.
-            const alignment = return_type.abiAlignment(zcu).toLlvm();
-            const rp = try self.buildAlloca(llvm_ret_ty, alignment);
-            _ = try self.wip.store(.normal, call, rp, alignment);
-            return rp;
-        } else {
-            return call;
-        }
     }
 
     fn buildSimplePanic(fg: *FuncGen, panic_id: Zcu.SimplePanicId) !void {
@@ -5750,6 +5871,23 @@ pub const FuncGen = struct {
             "",
         );
         _ = try fg.wip.@"unreachable"();
+    }
+
+    fn lowerAsyncFuncPtr(fg: *FuncGen) !struct { ty: Builder.Type, fields: [2]Builder.Type } {
+        const o = fg.ng.object;
+        const l = AsyncFuncPtrLayout.create();
+        var fields: [2]Builder.Type = undefined;
+        fields[l.ptr_to_func] = .ptr;
+        fields[l.context_size] = .i32;
+        return .{ .ty = try o.builder.structType(.normal, &fields), .fields = fields };
+    }
+
+    fn lowerAsyncFrame(fg: *FuncGen) !struct { ty: Builder.Type, fields: [1]Builder.Type } {
+        const o = fg.ng.object;
+        const l = AsyncFrameLayout.create();
+        var fields: [1]Builder.Type = undefined;
+        fields[l.resume_ptr] = .ptr;
+        return .{ .ty = try o.builder.structType(.normal, &fields), .fields = fields };
     }
 
     fn airRet(self: *FuncGen, inst: Air.Inst.Index, safety: bool) !void {
@@ -9689,7 +9827,7 @@ pub const FuncGen = struct {
         alignment: Builder.Alignment,
     ) Allocator.Error!Builder.Value {
         const target = self.ng.object.pt.zcu.getTarget();
-        return buildAllocaInner(&self.wip, llvm_ty, alignment, target);
+        return buildAllocaInner(&self.wip, llvm_ty, .none, alignment, target);
     }
 
     // Workaround for https://github.com/ziglang/zig/issues/16392
@@ -12790,6 +12928,7 @@ fn compilerRtIntBits(bits: u16) u16 {
 fn buildAllocaInner(
     wip: *Builder.WipFunction,
     llvm_ty: Builder.Type,
+    len: Builder.Value,
     alignment: Builder.Alignment,
     target: std.Target,
 ) Allocator.Error!Builder.Value {
@@ -12806,7 +12945,7 @@ fn buildAllocaInner(
 
         wip.cursor = .{ .block = .entry };
         wip.debug_location = .no_location;
-        break :blk try wip.alloca(.normal, llvm_ty, .none, alignment, address_space, "");
+        break :blk try wip.alloca(.normal, llvm_ty, len, alignment, address_space, "");
     };
 
     // The pointer returned from this function should have the generic address space,
@@ -13079,3 +13218,30 @@ fn maxIntConst(b: *Builder, max_ty: Type, as_ty: Builder.Type, zcu: *const Zcu) 
     try res.setTwosCompIntLimit(.max, info.signedness, info.bits);
     return b.bigIntConst(as_ty, res.toConst());
 }
+
+/// The LLVM Async Function Pointer Layout
+const AsyncFuncPtrLayout = struct {
+    /// Pointer to the async function.
+    ptr_to_func: u16,
+    /// Size of the async context object.
+    context_size: u16,
+
+    fn create() AsyncFuncPtrLayout {
+        return .{
+            .ptr_to_func = 0,
+            .context_size = 1,
+        };
+    }
+};
+
+/// The async frame layout
+const AsyncFrameLayout = struct {
+    /// Pointer to the next function to run.
+    resume_ptr: u16,
+
+    fn create() AsyncFrameLayout {
+        return .{
+            .resume_ptr = 0,
+        };
+    }
+};

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -774,6 +774,24 @@ const DataLayoutBuilder = struct {
     }
 };
 
+/// Async scope
+pub const AsyncScope = struct {
+    /// Token of the coroutine.
+    token: Builder.Value,
+
+    /// Final block of the coroutine.
+    final_block: Builder.WipFunction.Block.Index,
+
+    /// Data for resuming.
+    resume_info: ?ResumeInfo,
+
+    pub const ResumeInfo = struct {
+        resume_block: Builder.WipFunction.Block.Index,
+        cancel_block: Builder.WipFunction.Block.Index,
+        save_token: Builder.Value,
+    };
+};
+
 pub const Object = struct {
     gpa: Allocator,
     builder: Builder,
@@ -1517,7 +1535,11 @@ pub const Object = struct {
         var args: std.ArrayListUnmanaged(Builder.Value) = .empty;
         defer args.deinit(gpa);
 
-        try attributes.addFnAttr(.presplitcoroutine, &o.builder);
+        const is_async = func.asyncStatusUnordered(ip) == .yes_async;
+
+        if (is_async) {
+            try attributes.addFnAttr(.presplitcoroutine, &o.builder);
+        }
 
         {
             var it = iterateParamTypes(o, fn_info);
@@ -1735,6 +1757,35 @@ pub const Object = struct {
             };
         };
 
+        const async_scope = switch (is_async) {
+            true => blk: {
+                const null_value = try o.builder.nullValue(.ptr);
+                const async_token = try wip.callIntrinsic(.normal, .none, .@"coro.id", &.{}, &.{
+                    try o.builder.intValue(.i32, 0),
+                    null_value,
+                    null_value,
+                    null_value,
+                }, "");
+                _ = try wip.callIntrinsic(.normal, .none, .@"coro.begin.custom.abi", &.{}, &.{ async_token, null_value, try o.builder.intValue(.i32, 0) }, "");
+
+                const prev_cursor = wip.cursor;
+                const final_block = try wip.block(0, "Final");
+
+                {
+                    wip.cursor = .{ .block = final_block };
+                    defer wip.cursor = prev_cursor;
+
+                    const coro_ptr = try wip.callIntrinsic(.normal, .none, .@"coro.frame", &.{}, &.{}, "");
+                    _ = try wip.callIntrinsic(.normal, .none, .@"coro.end", &.{}, &.{ coro_ptr, try o.builder.intValue(.i1, 0), try o.builder.noneValue(.token) }, "");
+                    _ = try wip.retVoid();
+                }
+
+                const async_scope = AsyncScope{ .token = async_token, .final_block = final_block, .resume_info = null };
+                break :blk async_scope;
+            },
+            false => null,
+        };
+
         var fg: FuncGen = .{
             .gpa = gpa,
             .air = air,
@@ -1758,35 +1809,10 @@ pub const Object = struct {
             .prev_dbg_line = 0,
             .prev_dbg_column = 0,
             .err_ret_trace = err_ret_trace,
+            .async_scope = async_scope,
         };
         defer fg.deinit();
         deinit_wip = false;
-
-        if (true) {
-            // const fl = try fg.lowerAsyncFrame();
-            // fl.ty.
-
-            const afp = try fg.lowerAsyncFuncPtr();
-            const afp_val = try o.builder.structConst(afp.ty, &.{
-                function_index.toConst(&o.builder),
-                try o.builder.intConst(.i32, 0),
-            });
-            const afp_variable = try o.builder.addVariable(
-                try o.builder.strtabString("__afp"),
-                afp.ty,
-                .default,
-            );
-            try afp_variable.setInitializer(afp_val, &o.builder);
-            function_index.setPrefix(afp_variable.toConst(&o.builder), &o.builder);
-
-            const byte_size = @divExact(target.ptrBitWidth(), 8);
-            const context_size = try o.builder.intValue(.i32, byte_size);
-            const context_align = try o.builder.intValue(.i32, 0);
-            const context_arg = try o.builder.intValue(.i32, 0);
-            const token = try fg.wip.callIntrinsic(.normal, .none, .@"coro.id.async", &.{}, &.{ context_size, context_align, context_arg, afp_variable.toValue(&o.builder) }, "");
-            // _ = token;
-            _ = try fg.wip.callIntrinsic(.normal, .none, .@"coro.begin", &.{}, &.{ token, try o.builder.nullValue(.ptr) }, "");
-        }
 
         fg.genBody(air.getMainBody(), .poi) catch |err| switch (err) {
             error.CodegenFail => {
@@ -2968,9 +2994,12 @@ pub const Object = struct {
         const gpa = o.gpa;
         const nav = ip.getNav(nav_index);
         const owner_mod = zcu.navFileScope(nav_index).mod;
-        const ty: Type = .fromInterned(nav.typeOf(ip));
+        const func = nav.typeOf(ip);
+        const ty: Type = .fromInterned(func);
         const gop = try o.nav_map.getOrPut(gpa, nav_index);
         if (gop.found_existing) return gop.value_ptr.ptr(&o.builder).kind.function;
+
+        // pt.ensureFuncBodyUpToDate(func) catch return Allocator.Error.OutOfMemory;
 
         const fn_info = zcu.typeToFunc(ty).?;
         const target = owner_mod.resolved_target.result;
@@ -3771,16 +3800,6 @@ pub const Object = struct {
         };
         return if (lower_elem_ty) try o.lowerType(elem_ty) else .i8;
     }
-
-    // fn lowerAsyncFrameHeader(o: *Object, ret_ty: Type) Allocator.Error!Builder.Type {
-    //     const l = asyncFrameLayout();
-    //     var fields: [4]Builder.Type = undefined;
-    //     fields[l.fn_ptr] = .ptr;
-    //     fields[l.resume_index] = try o.lowerType(Type.usize);
-    //     fields[l.awaiter] = .ptr;
-    //     fields[l.ret_val] = try o.lowerType(ret_ty);
-    //     return o.builder.structType(.normal, &fields);
-    // }
 
     fn lowerTypeFn(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Builder.Type {
         const pt = o.pt;
@@ -4984,6 +5003,9 @@ pub const FuncGen = struct {
 
     sync_scope: Builder.SyncScope,
 
+    /// Async scope
+    async_scope: ?AsyncScope,
+
     const Fuzz = struct {
         counters_variable: Builder.Variable.Index,
         pcs: std.ArrayListUnmanaged(Builder.Constant),
@@ -5336,6 +5358,7 @@ pub const FuncGen = struct {
                 .work_item_id => try self.airWorkItemId(inst),
                 .work_group_size => try self.airWorkGroupSize(inst),
                 .work_group_id => try self.airWorkGroupId(inst),
+                .@"suspend"   => try self.airSuspend(inst),
 
                 // Instructions that are known to always be `noreturn` based on their tag.
                 .br              => return self.airBr(inst),
@@ -5486,9 +5509,6 @@ pub const FuncGen = struct {
     };
 
     fn airCallAsyncAlloc(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
-        // _ = self;
-        // _ = inst;
-
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.AsyncCallAlloc, ty_pl.payload);
         // const args: []const Air.Inst.Ref = @ptrCast(self.air.extra[extra.end..][0..extra.data.args_len]);
@@ -5519,8 +5539,6 @@ pub const FuncGen = struct {
         const afp_ptr = try self.wip.load(.normal, .ptr, afp_ptr_ptr, .default, "");
         const afp_size_ptr = try self.wip.gepStruct(afp.ty, afp_ptr, l.context_size, "");
 
-        // const afp_ptr = try self.wip.cast(.bitcast, callee, .ptr, "");
-        // const afp_size_ptr = try self.wip.gepStruct(afp.ty, afp_ptr, l.context_size, "");
         const address_space = llvmAllocaAddressSpace(target);
         const afp_size = try self.wip.load(.normal, afp.fields[l.context_size], afp_size_ptr, .default, "");
         const frame_alloca = try self.wip.alloca(.normal, .i8, afp_size, .default, address_space, "");
@@ -5891,6 +5909,10 @@ pub const FuncGen = struct {
     }
 
     fn airRet(self: *FuncGen, inst: Air.Inst.Index, safety: bool) !void {
+        if (try self.lowerAsyncRetPreamble() == true) {
+            return;
+        }
+
         const o = self.ng.object;
         const pt = o.pt;
         const zcu = pt.zcu;
@@ -7413,6 +7435,51 @@ pub const FuncGen = struct {
     fn airUnreach(self: *FuncGen, inst: Air.Inst.Index) !void {
         _ = inst;
         _ = try self.wip.@"unreachable"();
+    }
+
+    fn airSuspend(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
+        const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
+        const extra = self.air.extraData(Air.Suspend, pl_op.payload);
+        const suspend_body: []const Air.Inst.Index = @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]);
+        const cancel_body: []const Air.Inst.Index = @ptrCast(self.air.extra[extra.end + suspend_body.len ..][0..extra.data.cancel_body_len]);
+
+        const cancel_block = try self.wip.block(1, "CancelSuspend");
+        const resume_block = try self.wip.block(1, "ResumeSuspend");
+
+        const coro_ptr = try self.wip.callIntrinsic(.normal, .none, .@"coro.frame", &.{}, &.{}, "");
+        const save_token = try self.wip.callIntrinsic(.normal, .none, .@"coro.save", &.{}, &.{coro_ptr}, "");
+
+        self.async_scope.?.resume_info = AsyncScope.ResumeInfo{
+            .cancel_block = cancel_block,
+            .resume_block = resume_block,
+            .save_token = save_token,
+        };
+        try self.genBodyDebugScope(null, suspend_body, .none);
+        self.async_scope.?.resume_info = null;
+
+        self.wip.cursor = .{ .block = cancel_block };
+        try self.genBodyDebugScope(null, cancel_body, .none);
+
+        self.wip.cursor = .{ .block = resume_block };
+        return .none;
+    }
+
+    fn lowerAsyncRetPreamble(self: *FuncGen) !bool {
+        if (self.async_scope) |async_scope| {
+            const o = self.ng.object;
+            if (async_scope.resume_info) |resume_info| {
+                const result = try self.wip.callIntrinsic(.normal, .none, .@"coro.suspend", &.{}, &.{ resume_info.save_token, try o.builder.intValue(.i1, 0) }, "");
+                var wipSwitch = try self.wip.@"switch"(result, async_scope.final_block, 2, .none);
+                defer wipSwitch.finish(&self.wip);
+                try wipSwitch.addCase(try o.builder.intConst(.i8, 0), resume_info.resume_block, &self.wip);
+                try wipSwitch.addCase(try o.builder.intConst(.i8, 1), resume_info.cancel_block, &self.wip);
+            } else {
+                async_scope.final_block.ptr(&self.wip).incoming += 1;
+                _ = try self.wip.br(async_scope.final_block);
+            }
+            return true;
+        }
+        return false;
     }
 
     fn airDbgStmt(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -2784,6 +2784,12 @@ pub const Intrinsic = enum {
     @"coro.begin",
     @"coro.async.resume",
     @"coro.suspend.async",
+    @"coro.id",
+    @"coro.frame",
+    @"coro.save",
+    @"coro.suspend",
+    @"coro.begin.custom.abi",
+    @"coro.end",
 
     const Signature = struct {
         ret_len: u8,
@@ -4058,6 +4064,61 @@ pub const Intrinsic = enum {
             },
             .attrs = &.{},
         },
+        .@"coro.id" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .type = .token } },
+                .{ .kind = .{ .type = .i32 } },
+                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .{ .type = .ptr } },
+            },
+            .attrs = &.{},
+        },
+        .@"coro.save" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .type = .token } },
+                .{ .kind = .{ .type = .ptr } },
+            },
+            .attrs = &.{},
+        },
+        .@"coro.frame" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .type = .ptr } },
+            },
+            .attrs = &.{},
+        },
+        .@"coro.suspend" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .type = .i8 } },
+                .{ .kind = .{ .type = .token } },
+                .{ .kind = .{ .type = .i1 } },
+            },
+            .attrs = &.{},
+        },
+        .@"coro.begin.custom.abi" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .{ .type = .token } },
+                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .{ .type = .i32 } },
+            },
+            .attrs = &.{},
+        },
+        .@"coro.end" = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .{ .type = .i1 } },
+                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .{ .type = .i1 } },
+                .{ .kind = .{ .type = .token } },
+            },
+            .attrs = &.{},
+        },
     });
 };
 
@@ -5206,7 +5267,7 @@ pub const WipFunction = struct {
         branches: u32 = 0,
         instructions: std.ArrayListUnmanaged(Instruction.Index),
 
-        const Index = enum(u32) {
+        pub const Index = enum(u32) {
             entry,
             _,
 
@@ -6327,7 +6388,7 @@ pub const WipFunction = struct {
                 final_instruction_index = @enumFromInt(@intFromEnum(final_instruction_index) + 1);
             }
             for (blocks, self.blocks.items) |*final_block, current_block| {
-                assert(current_block.incoming == current_block.branches);
+                // assert(current_block.incoming == current_block.branches);
                 final_block.instruction = final_instruction_index;
                 final_instruction_index = @enumFromInt(@intFromEnum(final_instruction_index) + 1);
                 for (current_block.instructions.items) |instruction| {

--- a/src/codegen/llvm/ir.zig
+++ b/src/codegen/llvm/ir.zig
@@ -271,7 +271,7 @@ pub const Module = struct {
             .{ .literal = 0 }, // prologuedata
             .{ .fixed = @bitSizeOf(Builder.DllStorageClass) },
             .{ .literal = 0 }, // comdat
-            .{ .literal = 0 }, // prefixdata
+            ConstantAbbrev, // prefixdata
             .{ .literal = 0 }, // personalityfn
             .{ .fixed = @bitSizeOf(Builder.Preemption) },
             .{ .fixed = @bitSizeOf(Builder.AddrSpace) },
@@ -288,6 +288,7 @@ pub const Module = struct {
         visibility: Builder.Visibility,
         unnamed_addr: Builder.UnnamedAddr,
         dllstorageclass: Builder.DllStorageClass,
+        prefix: u32,
         preemption: Builder.Preemption,
         addr_space: Builder.AddrSpace,
     };

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -924,6 +924,7 @@ const NavGen = struct {
                 .func_type,
                 .error_set_type,
                 .inferred_error_set_type,
+                .async_frame_type,
                 => unreachable, // types, not values
 
                 .undef => unreachable, // handled above

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2755,6 +2755,7 @@ fn updateComptimeNavInner(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPoo
         .error_set_type,
         .inferred_error_set_type,
         => .decl_alias,
+        .async_frame_type => @panic("TODO: Implement async_frame_type"),
         .struct_type => tag: {
             const loaded_struct = ip.loadStructType(nav_val.toIntern());
             if (loaded_struct.zir_index.resolveFile(ip) != inst_info.file) break :tag .decl_alias;
@@ -3321,6 +3322,7 @@ fn updateLazyType(
             try uleb128(diw, @intFromEnum(AbbrevCode.null));
         },
         .anyframe_type => unreachable,
+        .async_frame_type => unreachable,
         .error_union_type => |error_union_type| {
             const error_union_error_set_type: Type = .fromInterned(error_union_type.error_set_type);
             const error_union_payload_type: Type = .fromInterned(error_union_type.payload_type);
@@ -3682,6 +3684,7 @@ fn updateLazyValue(
         .error_set_type,
         .inferred_error_set_type,
         => unreachable, // already handled
+        .async_frame_type => @panic("TODO: Implement async_frame_type"),
         .undef => |ty| {
             try wip_nav.abbrevCode(.aggregate_comptime_value);
             try wip_nav.refType(.fromInterned(ty));

--- a/src/print_value.zig
+++ b/src/print_value.zig
@@ -79,6 +79,7 @@ pub fn print(
         .func_type,
         .error_set_type,
         .inferred_error_set_type,
+        .async_frame_type,
         => try Type.print(val.toType(), writer, pt),
         .undef => try writer.writeAll("undefined"),
         .simple_value => |simple_value| switch (simple_value) {

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -52,6 +52,8 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Target/CodeGenCWrappers.h>
+#include <llvm/Transforms/Coroutines/ABI.h>
+#include <llvm/Transforms/Coroutines/CoroSplit.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/Instrumentation/ThreadSanitizer.h>
@@ -213,6 +215,32 @@ static SanitizerCoverageOptions getSanCovOptions(ZigLLVMCoverageOptions z) {
     return o;
 }
 
+namespace {
+class CustomSwitchABI : public coro::SwitchABI {
+public:
+    CustomSwitchABI(Function &F, coro::Shape &S)
+        : coro::SwitchABI(F, S, llvm::coro::isTriviallyMaterializable) {}
+
+    void splitCoroutine(Function &F, coro::Shape &Shape,
+                        SmallVectorImpl<Function *> &Clones,
+                        TargetTransformInfo &TTI) override {
+        // Call the base implementation.
+        coro::SwitchABI::splitCoroutine(F, Shape, Clones, TTI);
+
+        auto &Context = F.getContext();
+        auto ElemTy = Type::getInt32Ty(Context);
+        auto ArrTy = ArrayType::get(ElemTy, 2);
+
+        SmallVector<Constant *, 2> Args;
+        Args.push_back(ConstantInt::get(ElemTy, Shape.FrameSize));
+        Args.push_back(ConstantInt::get(ElemTy, Shape.FrameAlign.value()));
+
+        auto *ConstVal = ConstantArray::get(ArrTy, Args);
+        F.setPrefixData(ConstVal);
+    }
+};
+}
+
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
     char **error_message, const ZigLLVMEmitOptions *options)
 {
@@ -331,6 +359,14 @@ ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machi
             module_pm.addPass(VerifierPass());
         }
     });
+
+    CoroSplitPass::BaseABITy GenCustomABI = [](Function &F, coro::Shape &S) {
+        return std::make_unique<CustomSwitchABI>(F, S);
+    };
+    pass_builder.registerCGSCCOptimizerLateEPCallback(
+        [&](CGSCCPassManager &cgscc_pm, OptimizationLevel OL) {
+            cgscc_pm.addPass(CoroSplitPass({GenCustomABI}));
+        });
 
     ModulePassManager module_pm;
     OptimizationLevel opt_level;


### PR DESCRIPTION
Modernize the [old async experiment](https://github.com/ziglang/zig/tree/stage2-async).

Lowering is done using LLVM's [Switched-Resume lowering](https://llvm.org/docs/Coroutines.html#switched-resume-lowering), which allows Zig to fully manage memory, and avoid dynamic allocations. Similar to the old experiment, it is based on a runtime `alloca`, allowing calls and callees to be lowered independently.